### PR TITLE
use memcpy; strncpy will fail if there is a .0 anywhere in the address

### DIFF
--- a/linux/udp_reflector.cpp
+++ b/linux/udp_reflector.cpp
@@ -201,7 +201,7 @@ void create_socket()
         destination_points[i].dest_sock_addr.sin_family = AF_INET;
         destination_points[i].dest_sock_addr.sin_port = htons(
                 destination_points[i].dest_port);
-        strncpy((char *) &destination_points[i].dest_sock_addr.sin_addr,
+        memcpy((char *) &destination_points[i].dest_sock_addr.sin_addr,
                 (char *) dest_host_info->h_addr, dest_host_info->h_length);
 
         if (verbose_debug)


### PR DESCRIPTION
This took me most of the day to debug. I couldn't figure out why it was sending to 172.16.0.0 instead of 172.16.0.15. Ultimately my brother, @skohlsmith, identified the bug.
